### PR TITLE
Add missing gulp dependencies & fix multiline code formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "dependencies": {
   },
   "devDependencies": {
+    "gulp": "^3.8.11",
+    "gulp-sass": "^1.3.3",
     "gulp-webserver": "^0.9.0",
     "brfs": "^1.4.0",
     "es6-shim": "^0.30.0",

--- a/scss/rosetta-stone.scss
+++ b/scss/rosetta-stone.scss
@@ -80,6 +80,13 @@ header {
 	}
 }
 
+/* See http://projectcerbera.com/web/articles/code-in-pre#style */
+code {
+    white-space: pre-wrap;
+    white-space: -moz-pre-wrap;
+    white-space: -o-pre-wrap;
+}
+
 .chop-box {
 	overflow: hidden;
 	position: absolute;


### PR DESCRIPTION
Fixes #6.

All dependencies necessary can be installed with `npm install`.